### PR TITLE
Removed unnecessary bungeecord dependencies from sample psychics

### DIFF
--- a/psychics-abilities/magic-arrow/src/main/kotlin/com/github/noonmaru/psychics/ability/magicarrow/MagicArrow.kt
+++ b/psychics-abilities/magic-arrow/src/main/kotlin/com/github/noonmaru/psychics/ability/magicarrow/MagicArrow.kt
@@ -18,7 +18,6 @@ import com.github.noonmaru.tap.config.RangeDouble
 import com.github.noonmaru.tap.config.RangeLong
 import com.github.noonmaru.tap.effect.playFirework
 import com.github.noonmaru.tap.trail.trail
-import net.md_5.bungee.api.ChatColor
 import org.bukkit.*
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.LivingEntity


### PR DESCRIPTION
# Abstract
This PR **cleans up unnecessary bungeecord dependencies** (`net.md_5.bungee.api.ChatColor`)  
which is duplicate import (`org.bukkit.ChatColor` which is included in import statement `org.bukkit.*`) in [Line 22](https://github.com/Alex4386/psychics/commit/bd1ebbc516446ea9890212b08ad1ef86741842d8#diff-600c9e75f23efb86fc51b1425ea3ba7133d008b058fe7f2a297918299663a33eL22).  

# PSA
Double check your imports while using `Opt+Return` or `Alt+Enter`
