### PR TITLE
카운터 능력 타입 / 카운터 능력 클래스가 추가 되었으면 합니다.

### DIFF
--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/Ability.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/Ability.kt
@@ -217,6 +217,10 @@ abstract class ActiveAbility<T : AbilityConcept> : Ability<T>() {
     }
 }
 
+abstract class CounterAbility<T : AbilityConcept> : Ability<T>() {
+    abstract fun onAttacked(opponent: Esper, usedAbility: Ability<*>, tookDamage: Damage)
+}
+
 fun Ability<*>.targetFilter(): TargetFilter {
     return TargetFilter(esper.player)
 }

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/AbilityType.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/AbilityType.kt
@@ -25,7 +25,8 @@ enum class AbilityType(
 ) {
     PASSIVE(ChatColor.AQUA),
     ACTIVE(ChatColor.RED),
-    TOGGLE(ChatColor.YELLOW);
+    TOGGLE(ChatColor.YELLOW),
+    COUNTER(ChatColor.LIGHT_PURPLE);
 
     override fun toString(): String {
         return "$color$name"


### PR DESCRIPTION
개요
---
초능력 API로 개발하던 도중, 카운터 능력 타입의 필요성을 느끼게 되었습니다. 현재의 능력 타입 - 액티브 / 패시브 / 토글로는 능력 타입의 구분이 부족합니다.

카운터 능력 타입의 필요성
---
**능력을 지닌 플레이어가 다른 플레이어의 능력에 의해 피격당했을 때 그 피해량의 50%를 능력을 시전한 플레이어에게 되갚아주는** 능력을 개발하고 있었습니다. 그런데, 이 능력을 가지고 있는 사용자가 피격을 당했는지 그리고 타격한 사람이 누구인지와 같은 피격에 관한 정보를 능력 클래스에 전달하는 것이 번거롭고 어려웠습니다.

카운터 능력 타입이 도입되면
---
어떤 플레이어가 타격하는 순간에 그 플레이어가 타격하는 대상이 카운터 능력의 소유자인지 아닌지 판단하여, 카운터 능력의 소유자라면 정보를 넘겨주는 방식을 채택할 수 있습니다. 

추가 건의사항
---
카운터 능력 클래스가 따로 있다면 더 좋을 것이라 생각합니다. 하지만, 카운터 능력 타입의 도입이 우선적이라고 생각하여 이에 대해 먼저 pull request를 만들게 되었습니다.